### PR TITLE
fix(typos): fixes some small typos

### DIFF
--- a/examples/factory.rs
+++ b/examples/factory.rs
@@ -130,7 +130,7 @@ impl FactoryComponent<gtk::Box, AppMsg> for Counter {
         &mut self,
         msg: Self::Input,
         _input: &Sender<Self::Input>,
-        _ouput: &Sender<Self::Output>,
+        _output: &Sender<Self::Output>,
     ) -> Option<Self::Command> {
         match msg {
             CounterInput::Increment => {

--- a/examples/factory_advanced.rs
+++ b/examples/factory_advanced.rs
@@ -127,7 +127,7 @@ impl FactoryComponent<gtk::Grid, AppMsg> for Counter {
         &mut self,
         msg: Self::Input,
         _input: &Sender<Self::Input>,
-        _ouput: &Sender<Self::Output>,
+        _output: &Sender<Self::Output>,
     ) -> Option<Self::Command> {
         match msg {
             CounterMsg::Increment => {

--- a/src/0_4_to_0_5.md
+++ b/src/0_4_to_0_5.md
@@ -27,7 +27,7 @@ Components have three kinds of messages now:
 1. `Input` is the regular `Msg` type from the `Model` trait in 0.4.
 2. `Output` is the message type, that can be used to forward information to other components automatically (or `()` if you don't care about forwarding).
    You will find more information about initializing components in the next section.
-3. `CmdOuput` is the output of commands.
+3. `CmdOutput` is the output of commands.
    Commands are futures that are executed in the background.
    **They fully replace async workers.**
    The result of this future is the `CmdOutput` message handled in [`update_cmd`](https://relm4.org/docs/next/relm4/trait.Component.html#method.update_cmd), similar to the regular update function.
@@ -43,7 +43,7 @@ From the connector you can decide to automatically forward messages to another c
 The **controller** is the type you now **store in the model of the parent component** instead of creating a separate components struct.
 There's no `Components` trait necessary.
 
-For types that implement `Componet` that don't have any widgets (such as implementers of the [`Worker`](https://relm4.org/docs/next/relm4/worker/trait.Worker.html) trait), you can call [`detach_worker`](https://relm4.org/docs/next/relm4/component/struct.ComponentBuilder.html#method.detach_worker) from a `ComponentBuilder`.
+For types that implement `Component` that don't have any widgets (such as implementers of the [`Worker`](https://relm4.org/docs/next/relm4/worker/trait.Worker.html) trait), you can call [`detach_worker`](https://relm4.org/docs/next/relm4/component/struct.ComponentBuilder.html#method.detach_worker) from a `ComponentBuilder`.
 This spawns the internal runtime on a separate thread and gives you a [`WorkerController`](https://relm4.org/docs/next/relm4/worker/struct.WorkerController.html).
 
 ### Helper traits
@@ -63,7 +63,7 @@ Particularly, it doesn't support widgets and allows running the components updat
 
 Factories now work very similar to components.
 In fact, the new [`FactoryComponent`](https://relm4.org/docs/next/relm4/factory/traits/trait.FactoryComponent.html) trait that replaces `FactoryPrototype` is almost identical to the `Component` trait.
-Messages can now be optionally passed by using the [`ouput_to_parent_msg`](https://relm4.org/docs/next/relm4/factory/traits/trait.FactoryComponent.html#method.output_to_parent_msg) method.
+Messages can now be optionally passed by using the [`output_to_parent_msg`](https://relm4.org/docs/next/relm4/factory/traits/trait.FactoryComponent.html#method.output_to_parent_msg) method.
 
 `FactoryVec` was entirely removed in favor of `FactoryVecDeque`.
 Edits to factories are now similar to `Mutex` and require a guard.

--- a/src/components.md
+++ b/src/components.md
@@ -31,7 +31,7 @@ fn init(counter: Self::InitParams, root: &Self::Root, sender: &ComponentSender<S
             CounterOutput::MoveDown(index) => AppMsg::MoveDown(index),
         })  
     };
-    let widgets = view_outout!();
+    let widgets = view_output!();
     ComponentParts { model, widgets }
 }
 ```


### PR DESCRIPTION
I found some small typos in the documentation!