### PR TITLE
Update links

### DIFF
--- a/src/0_2_to_0_4.md
+++ b/src/0_2_to_0_4.md
@@ -38,4 +38,4 @@ Also, `RelmComponent::with_new_thread()` was removed due to the restructuring.
 It's recommended to use workers or message handlers for blocking operations instead.
 
 
-> If there's anything missing, let me know. You can simply open an issue on [GitHub](https://github.com/AaronErhardt/Relm4) or write a message in the [Matrix room](https://matrix.to/#/#relm4:matrix.org).
+> If there's anything missing, let me know. You can simply open an issue on [GitHub](https://github.com/Relm4/Relm4) or write a message in the [Matrix room](https://matrix.to/#/#relm4:matrix.org).

--- a/src/0_2_to_0_4.md
+++ b/src/0_2_to_0_4.md
@@ -6,7 +6,7 @@ Fortunately, there aren't many big breaking changes in version 0.4 despite a lot
 
 ## FactoryPrototype
 
-The methods of [`FactoryPrototype`](https://aaronerhardt.github.io/docs/relm4/relm4/factory/trait.FactoryPrototype.html) were renamed to better match the rest of Relm4's traits.
+The methods of [`FactoryPrototype`](https://relm4.org/docs/stable/relm4/factory/trait.FactoryPrototype.html) were renamed to better match the rest of Relm4's traits.
 
 + `generate` => `init_view`
 + `update` => `view`
@@ -20,7 +20,7 @@ The methods of [`FactoryPrototype`](https://aaronerhardt.github.io/docs/relm4/re
 
 ## Components
 
-The [`Components`](https://aaronerhardt.github.io/docs/relm4/relm4/trait.Components.html) trait now has a new method called `connect_parent`.
+The [`Components`](https://relm4.org/docs/stable/relm4/trait.Components.html) trait now has a new method called `connect_parent`.
 This method doesn't do much more than passing the parent widgets down to individual components and originated unintentionally in the rework of the initialization process.
 Because this method is usually just repetitive code, you can now use the derive macro instead:
 

--- a/src/components.md
+++ b/src/components.md
@@ -18,7 +18,7 @@ Components are mainly useful for separating parts of the UI into smaller, more m
 
 Let's write a small example app to see how components can be used in action. For this example, we write parts of an app that can edit images.
 
-> The app we will write in this chapter is also available [here](https://github.com/AaronErhardt/relm4/blob/main/relm4-examples/examples/components.rs). Run `cargo run --example components` from the [example directory](https://github.com/AaronErhardt/relm4/tree/main/relm4-examples) if you want to see the code in action.
+> The app we will write in this chapter is also available [here](https://github.com/Relm4/Relm4/blob/main/relm4-examples/examples/components.rs). Run `cargo run --example components` from the [example directory](https://github.com/Relm4/Relm4/tree/main/relm4-examples) if you want to see the code in action.
 
 ## The header bar
 

--- a/src/factory.md
+++ b/src/factory.md
@@ -17,7 +17,7 @@ Let's have a look at factories in Relm4. We want to write a simple application t
 
 The most common solution for storing collections of data is a `Vec`. Yet a `Vec` can't help us with efficient UI updates because it does not track changes to itself. If we used a `Vec` we'd have to assume everything could have changed and create all widgets over and over again. So instead we use a `FactoryVec` to store our data. A `FactoryVec` is a simple data structure provided by Relm4 that allows us to push, pop and modify elements. Additionally, it automatically keeps track of all the changes made to itself.
 
-> An overview over all available factory data structures can be found in the documentation [here](https://aaronerhardt.github.io/docs/relm4/relm4/factory/collections/index.html).
+> An overview over all available factory data structures can be found in the documentation [here](https://relm4.org/docs/stable/relm4/factory/collections/index.html).
 
 ```rust,no_run,noplayground
 {{#include ../examples/factory.rs:model }}

--- a/src/factory.md
+++ b/src/factory.md
@@ -11,7 +11,7 @@ Clicking on a counter will decrement it.
 
 Let's have a look at factories in Relm4. We want to write a simple application that can create and remove many counters. Each counter needs to store its value and display widgets to allow modifying the counter. In this example we will only decrement the counter.
 
-> The app we will write in this chapter is also available [here](https://github.com/AaronErhardt/relm4/blob/main/relm4-examples/examples/factory.rs). Run `cargo run --example factory` from the [example directory](https://github.com/AaronErhardt/relm4/tree/main/relm4-examples) if you want to see the code in action.
+> The app we will write in this chapter is also available [here](https://github.com/Relm4/Relm4/blob/main/relm4-examples/examples/factory.rs). Run `cargo run --example factory` from the [example directory](https://github.com/Relm4/Relm4/tree/main/relm4-examples) if you want to see the code in action.
 
 ### The model
 

--- a/src/factory_advanced.md
+++ b/src/factory_advanced.md
@@ -12,7 +12,7 @@ The `FactoryVec` we used in the previous chapter is sufficient for simple applic
 
 To show this, we'll create a similar counter app to the one of the previous chapter, but this time on **steroids**: we'll add functionality to add counters before and after a specific counter and to remove a certain counter. To get the required flexibility, we'll use the `FactoryVecDeque` type instead of a `FactoryVec`.
 
-> The app we will write in this chapter is also available [here](https://github.com/AaronErhardt/relm4/blob/main/relm4-examples/examples/factory_advanced.rs). Run `cargo run --example factory_advanced` from the [example directory](https://github.com/AaronErhardt/relm4/tree/main/relm4-examples) if you want to see the code in action.
+> The app we will write in this chapter is also available [here](https://github.com/Relm4/Relm4/blob/main/relm4-examples/examples/factory_advanced.rs). Run `cargo run --example factory_advanced` from the [example directory](https://github.com/Relm4/Relm4/tree/main/relm4-examples) if you want to see the code in action.
 
 ## Indices
 

--- a/src/factory_position.md
+++ b/src/factory_position.md
@@ -4,7 +4,7 @@ Most widgets such as `gtk::Box` don't use the position function because they are
 
 The task of the position function is mainly to map the index to a specific position/area (x, y, width and height) of a factory widget inside the parent widget (view).
 
-> The code we will use in this chapter is based on the grid_factory example [here](https://github.com/AaronErhardt/relm4/blob/main/relm4-examples/examples/grid_factory.rs). Run `cargo run --example grid_factory` from the [example directory](https://github.com/AaronErhardt/relm4/tree/main/relm4-examples) if you want to see the code in action.
+> The code we will use in this chapter is based on the grid_factory example [here](https://github.com/Relm4/Relm4/blob/main/relm4-examples/examples/grid_factory.rs). Run `cargo run --example grid_factory` from the [example directory](https://github.com/Relm4/Relm4/tree/main/relm4-examples) if you want to see the code in action.
 
 ## How it works
 

--- a/src/first_app.md
+++ b/src/first_app.md
@@ -150,7 +150,7 @@ The app does all those things in a loop. It waits for messages and once a messag
 
 I hope this chapter made everything clear for you :)
 
-If you found a mistake or there was something unclear, please open an issue [here](https://github.com/AaronErhardt/relm4/issues).
+If you found a mistake or there was something unclear, please open an issue [here](https://github.com/Relm4/Relm4/issues).
 
 As you have seen, initializing the UI was by far the largest part of our app, with roughly one half of the total code. In the next chapter, we will have a look at the `relm4-macros` crate that offers a macro that helps us to reduce the amount of code we need to implement the Widgets trait.
 

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -44,7 +44,7 @@ relm4-components = "0.2"
 
 ## Issues and feedback
 
-If you find a mistake or something unclear in Relm4 or this book, let me know! Simply open up an issue over at [GitHub](https://github.com/AaronErhardt/relm4/issues) or chat with us on [Matrix](https://matrix.to/#/#relm4:matrix.org).
+If you find a mistake or something unclear in Relm4 or this book, let me know! Simply open up an issue over at [GitHub](https://github.com/Relm4/Relm4/issues) or chat with us on [Matrix](https://matrix.to/#/#relm4:matrix.org).
 
 ## Platform support
 
@@ -58,12 +58,12 @@ All platforms supported by GTK4 are available for Relm4 as well:
 
 If you prefer learning directly from examples, we got you covered!
 
-Many code examples in this book and many other examples can also be found in the [relm4-examples crate](https://github.com/AaronErhardt/relm4/tree/main/relm4-examples). Whenever an example is discussed in the book, the introduction will mention the name of the example and provide a link to it.
+Many code examples in this book and many other examples can also be found in the [relm4-examples crate](https://github.com/Relm4/Relm4/tree/main/relm4-examples). Whenever an example is discussed in the book, the introduction will mention the name of the example and provide a link to it.
 
 To setup the examples run
 
 ```bash
-git clone https://github.com/AaronErhardt/relm4.git
+git clone https://github.com/Relm4/Relm4.git
 cd relm4
 ```
 

--- a/src/message_handler.md
+++ b/src/message_handler.md
@@ -15,7 +15,7 @@ To keep it simple, we will create another counter app. Yet this time, every clic
 
 ![App screenshot dark](img/screenshots/simple-dark.png)
 
-> The app we will write in this chapter is also available [here](https://github.com/AaronErhardt/relm4/blob/main/relm4-examples/examples/non_blocking_async.rs). Run `cargo run --example non_blocking_async` from the [example directory](https://github.com/AaronErhardt/relm4/tree/main/relm4-examples) if you want to see the code in action.
+> The app we will write in this chapter is also available [here](https://github.com/Relm4/Relm4/blob/main/relm4-examples/examples/non_blocking_async.rs). Run `cargo run --example non_blocking_async` from the [example directory](https://github.com/Relm4/Relm4/tree/main/relm4-examples) if you want to see the code in action.
 
 ### The timing
 

--- a/src/reusable_components.md
+++ b/src/reusable_components.md
@@ -10,7 +10,7 @@ This is how the dialog looks like in the alert example:
 
 ![App screenshot dark](img/screenshots/reusable-alert-dark-2.png)
 
-> If you want to see an alert component, very similar to the one we will write in this chapter, used inside a Relm4 application have a look at the [“alert” example](https://github.com/AaronErhardt/relm4/blob/main/relm4-examples/examples/alert.rs). Run `cargo run --example alert` from the [example directory](https://github.com/AaronErhardt/relm4/tree/main/relm4-examples) if you want to see the code in action.
+> If you want to see an alert component, very similar to the one we will write in this chapter, used inside a Relm4 application have a look at the [“alert” example](https://github.com/Relm4/Relm4/blob/main/relm4-examples/examples/alert.rs). Run `cargo run --example alert` from the [example directory](https://github.com/Relm4/Relm4/tree/main/relm4-examples) if you want to see the code in action.
 
 Reusable components don’t know their parent component at the time they are implemented. So if they want to interact with their parent component, they must assume that their parent model implements a trait as an interface for the component.
 
@@ -80,7 +80,7 @@ The widgets have a generic type for the parent component with the expected trait
 
 We’re done! That’s your first reusable component.
 
-> You can find more examples of reusable components in the relm4-components crate [here](https://github.com/AaronErhardt/relm4/tree/main/relm4-components). You can also contribute your own reusable components to relm4-components :)
+> You can find more examples of reusable components in the relm4-components crate [here](https://github.com/Relm4/Relm4/tree/main/relm4-components). You can also contribute your own reusable components to relm4-components :)
 
 ## The complete code
 

--- a/src/threads_and_async.md
+++ b/src/threads_and_async.md
@@ -55,7 +55,7 @@ Instead of `RelmComponent::new` we used `RelmComponent::with_new_thread`. The sa
 
 ## Async
 
-Async update functions are exclusive for workers and message handlers currently (if you need async components please open an issue). If you enable the tokio-rt feature, you can use an `AsyncRelmWorker` type that uses an async update function from the `AsyncComponentUpdate` trait. Apart from that, they are just like normal workers that run in a new thread. The ["tokio" example](https://github.com/AaronErhardt/relm4/blob/main/relm4-examples/examples/tokio.rs) shows how this can be used with for async HTTP requests.
+Async update functions are exclusive for workers and message handlers currently (if you need async components please open an issue). If you enable the tokio-rt feature, you can use an `AsyncRelmWorker` type that uses an async update function from the `AsyncComponentUpdate` trait. Apart from that, they are just like normal workers that run in a new thread. The ["tokio" example](https://github.com/Relm4/Relm4/blob/main/relm4-examples/examples/tokio.rs) shows how this can be used with for async HTTP requests.
 
 ### Non blocking async
 
@@ -65,7 +65,7 @@ For example, if you have an app that fetches the avatar images of many users and
 
 There are three ways to improve this: 
 
-+ Create your own async runtime in message handler. This is shown in the [non_blocking_async example](https://github.com/AaronErhardt/relm4/blob/main/relm4-examples/examples/non_blocking_async.rs).
++ Create your own async runtime in message handler. This is shown in the [non_blocking_async example](https://github.com/Relm4/Relm4/blob/main/relm4-examples/examples/non_blocking_async.rs).
 + Send a vector with all avatar images you need to your worker, so it can send all asynchronous requests at once.
 + Spawn a new thread for each message that sends a HTTP request and sends a message back.
 
@@ -88,4 +88,4 @@ std::thread::spawn(move || {
 
 ### Async inside the main event loop
 
-GTK uses an event loop from glib to handle asynchronous events. In fact the senders we've been using all the time use channels on that event loop. This event loop also allows us to execute futures. Relm4 provides a `spawn_future` function to do exactly that. The only drawback of this is that most crates relying on a tokio runtime won't work and that the future is run on the main thread. The ["future" example](https://github.com/AaronErhardt/relm4/blob/main/relm4-examples/examples/future.rs) shows how this can be used.
+GTK uses an event loop from glib to handle asynchronous events. In fact the senders we've been using all the time use channels on that event loop. This event loop also allows us to execute futures. Relm4 provides a `spawn_future` function to do exactly that. The only drawback of this is that most crates relying on a tokio runtime won't work and that the future is run on the main thread. The ["future" example](https://github.com/Relm4/Relm4/blob/main/relm4-examples/examples/future.rs) shows how this can be used.

--- a/src/tracker.md
+++ b/src/tracker.md
@@ -143,7 +143,7 @@ Let's have a look at its first appearance:
 {{#include ../examples/tracker.rs:track1 }}
 ```
 
-The [`set_class_active`](https://aaronerhardt.github.io/docs/relm4/relm4/util/widget_plus/trait.WidgetPlus.html#tymethod.set_class_active) method is used to either activate or disable a CSS class. It takes two parameters, the first is the class itself and the second is a boolean which specifies if the class should be added (`true`) or removed (`false`).
+The [`set_class_active`](https://relm4.org/docs/stable/relm4/util/widget_plus/trait.WidgetPlus.html#tymethod.set_class_active) method is used to either activate or disable a CSS class. It takes two parameters, the first is the class itself and the second is a boolean which specifies if the class should be added (`true`) or removed (`false`).
 
 The first parameter of the `track!` macro will be used as a condition to check whether something has changed. If this condition is `true`, the `set_class_active` method will be called with all the parameters of the `track!` macro that follow the condition.
 

--- a/src/tracker.md
+++ b/src/tracker.md
@@ -79,7 +79,7 @@ So in short, the `tracker::track` macro provides different getters and setters t
 
 Let's build a simple app that shows two random icons and allows the user to set each of them to a new random icon. As a bonus, we want to show a fancy background color if both icons are the same.
 
-> The app we will write in this chapter is also available [here](https://github.com/AaronErhardt/relm4/blob/main/relm4-examples/examples/tracker.rs). Run `cargo run --example tracker` from the [example directory](https://github.com/AaronErhardt/relm4/tree/main/relm4-examples) if you want to see the code in action.
+> The app we will write in this chapter is also available [here](https://github.com/Relm4/Relm4/blob/main/relm4-examples/examples/tracker.rs). Run `cargo run --example tracker` from the [example directory](https://github.com/Relm4/Relm4/tree/main/relm4-examples) if you want to see the code in action.
 
 ## The icons
 

--- a/src/widget_macro.md
+++ b/src/widget_macro.md
@@ -74,7 +74,7 @@ The last special syntax of the `widgets` macro we'll cover here is the `watch!` 
 {{#include ../examples/simple.rs:watch }}
 ```
 
-> The full reference for the syntax of the widget macro can be found [here](https://aaronerhardt.github.io/relm4-book/book/widget_macro_reference.html).
+> The full reference for the syntax of the widget macro can be found [here](https://relm4.org/book/stable/widget_macro_reference.html).
 
 ## The complete code
 

--- a/src/widget_macro.md
+++ b/src/widget_macro.md
@@ -6,7 +6,7 @@ To simplify the implementation of the `Widgets` trait, let's use the relm4-macro
 
 The app will look and behave identical to our first app from the previous chapter. Only the implementation is different.
 
-> The app we will write in this chapter is also available [here](https://github.com/AaronErhardt/relm4/blob/main/relm4-examples/examples/simple.rs). Run `cargo run --example simple` from the [example directory](https://github.com/AaronErhardt/relm4/tree/main/relm4-examples) if you want to see the code in action.
+> The app we will write in this chapter is also available [here](https://github.com/Relm4/Relm4/blob/main/relm4-examples/examples/simple.rs). Run `cargo run --example simple` from the [example directory](https://github.com/Relm4/Relm4/tree/main/relm4-examples) if you want to see the code in action.
 
 ## What's different
 

--- a/src/widget_macro_expansion.md
+++ b/src/widget_macro_expansion.md
@@ -2,7 +2,7 @@
 
 To better understand the widget macro, we will have a look at how the different parts of the widget macro are translated into real Rust code (aka the macro expansion). Therefore, we will write a small app that uses as many widget macro features as possible.
 
-> The app we will write in this chapter is also available [here](https://github.com/AaronErhardt/relm4/blob/main/relm4-examples/examples/macro_test.rs). Run `cargo run --example macro_test` from the [example directory](https://github.com/AaronErhardt/relm4/tree/main/relm4-examples) if you want to see the code in action.
+> The app we will write in this chapter is also available [here](https://github.com/Relm4/Relm4/blob/main/relm4-examples/examples/macro_test.rs). Run `cargo run --example macro_test` from the [example directory](https://github.com/Relm4/Relm4/tree/main/relm4-examples) if you want to see the code in action.
 
 ## The boilerplate
 

--- a/src/widget_macro_expansion.md
+++ b/src/widget_macro_expansion.md
@@ -94,9 +94,9 @@ It's exactly the the code of the `pre_init()` function.
 
 #### Widget initialization
 
-The macro now initializes all widgets. Widgets that were defined by their type are initialized with the [`relm4::util::default_widgets::DefaultWidget`](https://aaronerhardt.github.io/docs/relm4/relm4/util/default_widgets/trait.DefaultWidget.html) trait that basically calls `Widget::builder().build()` to initialize a widget with default configuration. Obviously, that only works for widgets that support this builder pattern.
+The macro now initializes all widgets. Widgets that were defined by their type are initialized with the [`relm4::util::default_widgets::DefaultWidget`](https://relm4.org/docs/stable/relm4/util/default_widgets/trait.DefaultWidget.html) trait that basically calls `Widget::builder().build()` to initialize a widget with default configuration. Obviously, that only works for widgets that support this builder pattern.
 
-We also see `gtk::Button::new()` and `new_label()` used to initialize widgets. These widgets were explicitly initialized with a [function](https://aaronerhardt.github.io/relm4-book/book/widget_macro_reference.html#functions).
+We also see `gtk::Button::new()` and `new_label()` used to initialize widgets. These widgets were explicitly initialized with a [function](https://relm4.org/book/stable/widget_macro_reference.html#functions).
 
 ```rust,no_run,noplayground
 {{#include ../examples/macro_expansion.rs:widget_init }}


### PR DESCRIPTION
This goes supersedes the fix-links branch by updating docs and book links too, and it doesn't need to be rebased.