### PR TITLE
Pointed some of the links refering to docs to the new docs.rs urls

### DIFF
--- a/src/0_2_to_0_4.md
+++ b/src/0_2_to_0_4.md
@@ -6,7 +6,7 @@ Fortunately, there aren't many big breaking changes in version 0.4 despite a lot
 
 ## FactoryPrototype
 
-The methods of [`FactoryPrototype`](https://relm4.org/docs/stable/relm4/factory/trait.FactoryPrototype.html) were renamed to better match the rest of Relm4's traits.
+The methods of `FactoryPrototype` were renamed to better match the rest of Relm4's traits.
 
 + `generate` => `init_view`
 + `update` => `view`
@@ -20,7 +20,7 @@ The methods of [`FactoryPrototype`](https://relm4.org/docs/stable/relm4/factory/
 
 ## Components
 
-The [`Components`](https://relm4.org/docs/stable/relm4/trait.Components.html) trait now has a new method called `connect_parent`.
+The `Components` trait now has a new method called `connect_parent`.
 This method doesn't do much more than passing the parent widgets down to individual components and originated unintentionally in the rework of the initialization process.
 Because this method is usually just repetitive code, you can now use the derive macro instead:
 

--- a/src/tracker.md
+++ b/src/tracker.md
@@ -143,7 +143,7 @@ Let's have a look at its first appearance:
 {{#include ../examples/tracker.rs:track1 }}
 ```
 
-The [`set_class_active`](https://relm4.org/docs/stable/relm4/util/widget_plus/trait.WidgetPlus.html#tymethod.set_class_active) method is used to either activate or disable a CSS class. It takes two parameters, the first is the class itself and the second is a boolean which specifies if the class should be added (`true`) or removed (`false`).
+The [`set_class_active`](https://docs.rs/relm4/latest/relm4/trait.RelmWidgetExt.html#tymethod.set_class_active) method is used to either activate or disable a CSS class. It takes two parameters, the first is the class itself and the second is a boolean which specifies if the class should be added (`true`) or removed (`false`).
 
 The first parameter of the `track!` macro will be used as a condition to check whether something has changed. If this condition is `true`, the `set_class_active` method will be called with all the parameters of the `track!` macro that follow the condition.
 


### PR DESCRIPTION
There are still a few other links that point to docs which I haven't changed. That's because the referred page does not exist in 0.5 (or I don't know what they are called now). Those changes need to be done when the relevant part of the book is adapted to the new version.

I removed the links in the migration guide, because once the documentation is moved to docs.rs, there will be no documentation for 0.4 or any previous versions anyways.