### PR TITLE
Add continuous integration guide

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -26,6 +26,7 @@
 - [Widget templates](widget_templates.md)
 - [gtk-rs overview](gtk_rs.md)
 - [Resource Bundles](resource_bundles.md)
+- [Continuous Integration guide](continuous_integration.md)
 - [Component macro reference](component_macro/reference.md)
   - [Macro expansion](component_macro/expansion.md)
 - [Migration guides](migrations/index.md)

--- a/src/continuous_integration.md
+++ b/src/continuous_integration.md
@@ -1,0 +1,36 @@
+# Continuous Integration
+
+We recommend that you establish a CI build for your Relm4 app. This guide describes how to do it, and the caveats you must observe to make the build work.
+
+## GitHub Actions
+
+Starting with Relm 0.6.1, you can set up a CI build for your app on GitHub Actions.
+
+If your project builds with Cargo in a reasonably self-contained way (e.g. using `build.rs` to do packaging rather than external shell scripts), you can do this with an almost entirely standard Cargo build workflow, as shown below.
+
+**Caveats:**
+
+- You must `apt-get install` the relevant system libraries for the parts of GTK or Adwaita that your Relm4 app uses.
+- You must synchronise the GNOME version your app uses with the GNOME version available on the GitHub Actions runner. (For example, on the standard Ubuntu 22.04 runner, you must use GNOME 42.) Set this in Cargo.toml with `relm4 = { features = ["gnome_<version>"] }`.
+
+```yaml
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - run: sudo apt-get update
+    - run: sudo apt-get install -y libgtk-4-dev libadwaita-1-dev
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+```

--- a/src/continuous_integration.md
+++ b/src/continuous_integration.md
@@ -6,12 +6,7 @@ We recommend that you establish a CI build for your Relm4 app. This guide descri
 
 Starting with Relm 0.6.1, you can set up a CI build for your app on GitHub Actions.
 
-If your project builds with Cargo in a reasonably self-contained way (e.g. using `build.rs` to do packaging rather than external shell scripts), you can do this with an almost entirely standard Cargo build workflow, as shown below.
-
-**Caveats:**
-
-- You must `apt-get install` the relevant system libraries for the parts of GTK or Adwaita that your Relm4 app uses.
-- You must synchronise the GNOME version your app uses with the GNOME version available on the GitHub Actions runner. (For example, on the standard Ubuntu 22.04 runner, you must use GNOME 42.) Set this in Cargo.toml with `relm4 = { features = ["gnome_<version>"] }`.
+We recommend that you use the [`gtk4-rs`](https://github.com/gtk-rs/gtk4-rs/pkgs/container/gtk4-rs%2Fgtk4) container approach, as shown below:
 
 ```yaml
 name: Rust
@@ -24,13 +19,19 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest # TODO enable minor version tags / pinning
     steps:
     - uses: actions/checkout@v3
-    - run: sudo apt-get update
-    - run: sudo apt-get install -y libgtk-4-dev libadwaita-1-dev
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
     - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      run: cargo build
+    - name: Test
+      run: cargo test
 ```
+
+**Note:** You *can* alternatively just run the `cargo build` on the `ubuntu-latest` base image. However, this will tie your Relm app's GNOME and GTK version to Ubuntu's 2-year LTS release cycle, so you will not be able to use newer GNOME / GTK versions in the meantime. We therefore recommend that most projects use the `gtk4-rs` container approach instead.


### PR DESCRIPTION
Add a guide for setting up CI builds for Relm apps, including the caveats that must be observed to make them build correctly.