### PR TITLE
Minor cleanups

### DIFF
--- a/examples/factory.rs
+++ b/examples/factory.rs
@@ -35,13 +35,13 @@ impl FactoryComponent for Counter {
     type Input = CounterMsg;
     type Output = CounterOutput;
     type CommandOutput = ();
-    type Widgets = CounterWidgets;
     type ParentWidget = gtk::Box;
     // ANCHOR_END: factory_impl_start
 
     // ANCHOR: factory_view
     view! {
-        root = gtk::Box {
+        #[root]
+        gtk::Box {
             set_orientation: gtk::Orientation::Horizontal,
             set_spacing: 10,
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -35,18 +35,14 @@ impl SimpleComponent for AppModel {
 
                 gtk::Button {
                     set_label: "Increment",
-                    connect_clicked[sender] => move |_| {
-                        sender.input(AppMsg::Increment);
-                    }
+                    connect_clicked => AppMsg::Increment
                 },
 
                 // ANCHOR: widget_assign_fn
                 gtk::Button::with_label("Decrement") {
                 // ANCHOR_END: widget_assign_fn
                 // ANCHOR: connect
-                    connect_clicked[sender] => move |_| {
-                        sender.input(AppMsg::Decrement);
-                    }
+                    connect_clicked => AppMsg::Decrement
                 // ANCHOR_END: connect
                 },
 

--- a/src/component_macro.md
+++ b/src/component_macro.md
@@ -48,7 +48,7 @@ Sometimes we want to use a constructor function to initialize our widgets. For t
 
 ### Events
 
-To connect events, we use this syntax:
+To connect events, we use this general syntax:
 
 ```rust,no_run,noplayground
 method_name[cloned_var1, cloned_var2, ...] => move |args, ...| { code... }
@@ -56,22 +56,23 @@ method_name[cloned_var1, cloned_var2, ...] => move |args, ...| { code... }
 
 Again, there's no magic. The macro will simply assign a closure to a method. Because closures often need to capture local variables that don't implement the `Copy` trait, we need to clone these variables. Therefore, we can list the variables we want to clone in the square brackets after the method name.
 
+For simple cases there's even a shorter syntax for just sending one input message that works with most event handlers.
+So instead of this:
+```rust,no_run,noplayground
+method_name[sender] => move |_| { sender.input(Msg); },
+```
+
+You can simply write this:
+
+```rust,no_run,noplayground
+method_name => Msg,
+```
+
+This is what we used in this example:
+
 ```rust,no_run,noplayground
 {{#include ../examples/simple.rs:connect }}
 ```
-
-> There's even a shorter syntax for just sending one input message that works with most event handlers.
-> So instead of this:
-> 
-> ```rust,no_run,noplayground
-> method_name[sender] => move |_| { sender.input(Msg); },
-> ```
-> 
-> You can simply write this:
-> 
-> ```rust,no_run,noplayground
-> method_name => Msg,
-> ```
 
 ### UI updates
 

--- a/src/efficient_ui/factory.md
+++ b/src/efficient_ui/factory.md
@@ -78,7 +78,6 @@ Let's look at the associated types one by one:
 + **Input**: The input message type.
 + **Output**: The output message type.
 + **CommandOutput**: The command output message type, we don't need it here.
-+ **Widgets**: The name of the struct that stores out widgets, it will be created by the macro.
 + **ParentWidget**: The container widget used to store the widgets of the factory, for example `gtk::Box`.
 
 ### Creating the widget


### PR DESCRIPTION
These examples make code a bit cleaner, better showcasing how easy it is to work with relm4.

I also think `type Widgets` should be removed from other places since it'll be auto-generated and user likely doesn't care about its name.

On a different note I think it'll clean up examples more if preludes are used as `use gtk::prelude::*;` cleaning up some clutter at the top of the file.