### PR TITLE
tracker: Update docs about tracker, Relm4/Relm4#741

### DIFF
--- a/examples/tracker.rs
+++ b/examples/tracker.rs
@@ -22,6 +22,15 @@ fn random_icon_name() -> &'static str {
         .choose(&mut rand::thread_rng())
         .expect("Could not choose a random icon")
 }
+
+// Returns a random icon different from the excluded one (avoids repeats).
+fn gen_unique_icon(exclude: &'static str) -> &'static str {
+    let mut rnd = random_icon_name();
+    while rnd == exclude {
+        rnd = random_icon_name()
+    }
+    rnd
+}
 // ANCHOR_END: icons
 
 // The track proc macro allows to easily track changes to different
@@ -126,10 +135,10 @@ impl SimpleComponent for AppModel {
 
         match message {
             AppInput::UpdateFirst => {
-                self.set_first_icon(random_icon_name());
+                self.set_first_icon(gen_unique_icon(self.first_icon));
             }
             AppInput::UpdateSecond => {
-                self.set_second_icon(random_icon_name());
+                self.set_second_icon(gen_unique_icon(self.second_icon));
             }
         }
         self.set_identical(self.first_icon == self.second_icon);

--- a/src/efficient_ui/tracker.md
+++ b/src/efficient_ui/tracker.md
@@ -81,7 +81,7 @@ Let's build a simple app that shows two random icons and allows the user to set 
 
 ## The icons
 
-Before we can select random icons, we need to quickly implement a function that will return us random image names available in the default GTK icon theme.
+Before selecting random icons, we need implement two functions, one for return random image name from the default GTK icon theme, and another that makes sure that when the images are updated, their names are not repeated.
 
 ```rust,no_run,noplayground
 {{#include ../../examples/tracker.rs:icons }}
@@ -105,6 +105,8 @@ There are a few notable things for the `Component`'s `update` implementation.
 First, we call `self.reset()` at the top of the function body. This ensures that the tracker will be reset so we don't track old changes.
 
 Also, we use setters instead of assignments because we want to track these changes. Yet, you could still use the assignment operator if you want to apply changes without notifying the tracker.
+
+The `gen_unique_icon()` function ensures the new icon won't match the current one, preventing visually identical updates.
 
 ```rust,no_run,noplayground
 {{#include ../../examples/tracker.rs:update }}


### PR DESCRIPTION
tracker.rs
---
Port of gen_unique_icon() from Relm4/Relm4#741

- Direct implementation of upstream's unique icon generation
- Preserves all original functionality 

tracker.md
---
- Restated sentence with changes about two functions
- New sentence, that describe behavior new function "gen_unique_icon()"