### PR TITLE
Fix incorrect conditional widget syntax

### DIFF
--- a/src/component_macro/reference.md
+++ b/src/component_macro/reference.md
@@ -126,7 +126,8 @@ Internally, the macro will use a `gtk::Stack`, so you can also use different [tr
 if model.value % 2 == 0 {
     gtk::Label {
         set_label: "The value is even",
-    },
+    }
+} else {
     gtk::Label {
         set_label: "The value is odd",
     }


### PR DESCRIPTION
Fixes the `if`-based conditional widget syntax in the component macro reference.

Fixes https://github.com/Relm4/Relm4/issues/905.